### PR TITLE
Encode the GitHub bearer token in the returned JWT

### DIFF
--- a/auth_backend/jwt_authentication.py
+++ b/auth_backend/jwt_authentication.py
@@ -46,7 +46,7 @@ class JWTAuthentication(object):
             logger.error(error_msg)
             return format_response(500, {"error": error_msg})
 
-        return self.format_jwt(userid)
+        return self.format_jwt(userid, bearer_token)
 
     def refresh_jwt(self):
         current_jwt = self.payload.get("token")
@@ -76,7 +76,7 @@ class JWTAuthentication(object):
             logger.info(error_msg)
             return format_response(401, {"error": error_msg})
 
-        return self.format_jwt(userid)
+        return self.format_jwt(userid, bearer_token)
 
     def retrieve_bearer_token(self, access_code):
         payload = {
@@ -123,11 +123,12 @@ class JWTAuthentication(object):
         gh_response = r.json()
         return gh_response.get('user').get('id')
 
-    def format_jwt(self, userid):
+    def format_jwt(self, userid, bearer_token):
         data = {
             'iat': datetime.datetime.utcnow(),
             'exp': datetime.datetime.utcnow() + datetime.timedelta(minutes=10),
-            "sub": userid
+            "sub": userid,
+            "github_token": bearer_token
         }
         encoded = jwt.encode(data, self.jwt_signing_secret, algorithm='HS256')
         return format_response(200, {"token": encoded})

--- a/tests/test_jwt_auth_refresh_token.py
+++ b/tests/test_jwt_auth_refresh_token.py
@@ -100,3 +100,16 @@ class TestJWTAuthRefreshToken(unittest.TestCase):
         result = auth.refresh_jwt()
         self.assertEqual(result.get('http_status'), 200)
         self.assertTrue("token" in result.get('data'))
+
+    def test_github_token_field_presence(self):
+        token = jwt.encode({"sub": "user1"},
+                           self.jwt_signing_secret,
+                           algorithm='HS256')
+        payload = {"token": token}
+        self.lambda_event['payload'] = payload
+        auth = JWTAuthentication(self.lambda_event)
+        result = auth.format_jwt("bob", "bobstoken")
+        self.assertEqual(result.get('http_status'), 200)
+        jwt_token = result.get('data').get('token')
+        decoded_token = jwt.decode(jwt_token, verify=False)
+        self.assertEqual(decoded_token.get('github_token'), "bobstoken")


### PR DESCRIPTION
This will make it more efficient for the client to make calls directly to GitHub, using their own bearer token.
