### PR TITLE
Encode the GitHub username inside the JSON Web Token

### DIFF
--- a/tests/test_jwt_auth_new_token.py
+++ b/tests/test_jwt_auth_new_token.py
@@ -85,7 +85,7 @@ class TestJWTAuthNewToken(unittest.TestCase):
         result_json = json.loads(str(cm.exception))
         self.assertEqual(result_json.get('http_status'), 401)
         self.assertEqual(result_json.get('data').get('error'),
-                         "Could not find GitHub user id")
+                         "Could not find GitHub user information")
 
     def test_unable_to_persist_bearer_token(self):
         payload = {"password": "code123"}
@@ -97,7 +97,8 @@ class TestJWTAuthNewToken(unittest.TestCase):
         self.mock_requests.get.return_value.status_code = 200
         self.mock_requests.get.return_value.json.return_value = {
             "user": {
-                "id": "u123"
+                "id": "u123",
+                "login": "bob"
             }
         }
         jwt.store_bearer_token = MagicMock()
@@ -119,7 +120,8 @@ class TestJWTAuthNewToken(unittest.TestCase):
         self.mock_requests.get.return_value.status_code = 200
         self.mock_requests.get.return_value.json.return_value = {
             "user": {
-                "id": "u123"
+                "id": "u123",
+                "login": "bob"
             }
         }
         jwt.store_bearer_token = MagicMock()

--- a/tests/test_jwt_auth_refresh_token.py
+++ b/tests/test_jwt_auth_refresh_token.py
@@ -80,8 +80,8 @@ class TestJWTAuthRefreshToken(unittest.TestCase):
         auth.jwt_signing_secret = self.jwt_signing_secret
         auth.lookup_bearer_token = MagicMock()
         auth.lookup_bearer_token.return_value = "suchtoken"
-        auth.retrieve_gh_user_id = MagicMock()
-        auth.retrieve_gh_user_id.return_value = None
+        auth.retrieve_gh_user_info = MagicMock()
+        auth.retrieve_gh_user_info.return_value = (None, None)
         with self.assertRaises(TypeError) as cm:
             auth.refresh_jwt()
         result_json = json.loads(str(cm.exception))
@@ -95,8 +95,8 @@ class TestJWTAuthRefreshToken(unittest.TestCase):
         auth.jwt_signing_secret = self.jwt_signing_secret
         auth.lookup_bearer_token = MagicMock()
         auth.lookup_bearer_token.return_value = "suchtoken"
-        auth.retrieve_gh_user_id = MagicMock()
-        auth.retrieve_gh_user_id.return_value = "manytokenseven"
+        auth.retrieve_gh_user_info = MagicMock()
+        auth.retrieve_gh_user_info.return_value = ("manytokenseven", "bob")
         result = auth.refresh_jwt()
         self.assertEqual(result.get('http_status'), 200)
         self.assertTrue("token" in result.get('data'))
@@ -108,8 +108,9 @@ class TestJWTAuthRefreshToken(unittest.TestCase):
         payload = {"token": token}
         self.lambda_event['payload'] = payload
         auth = JWTAuthentication(self.lambda_event)
-        result = auth.format_jwt("bob", "bobstoken")
+        result = auth.format_jwt("123", "bob", "bobstoken")
         self.assertEqual(result.get('http_status'), 200)
         jwt_token = result.get('data').get('token')
         decoded_token = jwt.decode(jwt_token, verify=False)
+        self.assertEqual(decoded_token.get('github_login'), "bob")
         self.assertEqual(decoded_token.get('github_token'), "bobstoken")


### PR DESCRIPTION
The reasoning for this is a combination of GitHub's API paths (`/users/<login>` vs `/user`) and ember data.

If this login information were not inside the JWT, GitHub would need to be queried via the `/user` endpoint. This is well and good until ember data comes into play and likes pluralization to be a certain way.

What this came down to was either modify the ember data model (update pluralization, among other things), or add the login field to the JWT.

This seemed like the easier and more maintainable approach.
